### PR TITLE
Bugfix

### DIFF
--- a/backslip_tools/make_strainG.m
+++ b/backslip_tools/make_strainG.m
@@ -13,13 +13,13 @@ GExx = zeros(size(xystats,1),npatches);
 GExy = zeros(size(xystats,1),npatches);
 GEyy = zeros(size(xystats,1),npatches);
 
+pm(:,3) = pm(:,3)+1; %small shift to avoid physically impossible error
 
 for k=1:npatches
     
     ss= cos(rake(k)*pi/180);
     ds = sin(rake(k)*pi/180);   
     
-    pm(:,3) = pm(:,3)+1; %small shift to avoid physically impossible error
     m1=[pm(k,:) ss ds 0]';  %positive slip is R and LL sense
    
     [U1,D,S,flag]=disloc3d(m1,xloc,1,.25);

--- a/backslip_tools/make_strainG_piecewise.m
+++ b/backslip_tools/make_strainG_piecewise.m
@@ -24,6 +24,7 @@ for k=1:npatches
     %divide into small segments 
     nhe = ceil(pm(k,1)/refine);
     pf = patchfault(pm(k,:),nhe,1);
+    pf(:,3) = pf(:,3)+1; %small shift to avoid physically impossible error
     
     Exx1 = zeros(size(xystats,1),1);
     Exx2 = zeros(size(xystats,1),1);
@@ -38,7 +39,6 @@ for k=1:npatches
     
     for j=1:nhe
         
-        pf(:,3) = pf(:,3)+1; %small shift to avoid physically impossible error
         m1=[pf(j,:) ss ds 0]';
    
         [U1,D,S,flag]=disloc3d(m1,xloc,1,.25);

--- a/build_backslip_GreensFunctions.m
+++ b/build_backslip_GreensFunctions.m
@@ -216,7 +216,7 @@ make_patches_backslip_deep_variableH
     G1Eyy_top,G2Eyy_top] = make_strainG_piecewise(pm_top,rake_top_patches,tri_centroids(:,1:2),refine);
 %combine matrices above to build G matrices
 [GExx_top_fine,GExy_top_fine,GEyy_top_fine]=...
-    build_G_backslip_function(G1Exx_top,G2Exx_top,G1Exy_top,G2Exy_top,G1Eyy_top,G2Eyy_top,pm_top_seg_num);
+    build_G_backslip_function(G1Exx_top,G2Exx_top,G1Exy_top,G2Exy_top,G1Eyy_top,G2Eyy_top,pm_top_seg_id);
 %clear variables no longer needed
 clear G1Exx_top G2Exx_top G1Exy_top G2Exy_top G1Eyy_top G2Eyy_top
 
@@ -231,7 +231,7 @@ if variable_rake
         G1Eyy_top,G2Eyy_top] = make_strainG_piecewise(pm_top,rake_top_patches+90,tri_centroids(:,1:2),refine);
     %combine matrices above to build G matrices
     [GExx_top_fine_perp,GExy_top_fine_perp,GEyy_top_fine_perp]=...
-        build_G_backslip_function(G1Exx_top,G2Exx_top,G1Exy_top,G2Exy_top,G1Eyy_top,G2Eyy_top,pm_top_seg_num);
+        build_G_backslip_function(G1Exx_top,G2Exx_top,G1Exy_top,G2Exy_top,G1Eyy_top,G2Eyy_top,pm_top_seg_id);
     %clear variables no longer needed
     clear G1Exx_top G2Exx_top G1Exy_top G2Exy_top G1Eyy_top G2Eyy_top
     

--- a/invert_strainrate_for_backslip.m
+++ b/invert_strainrate_for_backslip.m
@@ -102,9 +102,9 @@ else
 
     if variable_rake
         
-        GExx_top_perp = GExx_top_elastic + 1000*GExx_top_cycle_perp*10^-6; %convert from micro-strain/yr, convert from m/yr to mm/yr
-        GExy_top_perp = GExy_top_elastic + 1000*GExy_top_cycle_perp*10^-6;
-        GEyy_top_perp = GEyy_top_elastic + 1000*GEyy_top_cycle_perp*10^-6;
+        GExx_top_perp = GExx_top_elastic_perp + 1000*GExx_top_cycle_perp*10^-6; %convert from micro-strain/yr, convert from m/yr to mm/yr
+        GExy_top_perp = GExy_top_elastic_perp + 1000*GExy_top_cycle_perp*10^-6;
+        GEyy_top_perp = GEyy_top_elastic_perp + 1000*GEyy_top_cycle_perp*10^-6;
 
         GExx_perp = GExx_elastic_perp + 1000*GExx_cycle_perp*10^-6;
         GExy_perp = GExy_elastic_perp + 1000*GExy_cycle_perp*10^-6;
@@ -358,7 +358,7 @@ mu=30e9; %shear modulus
 
 %on fault
 %note about units; bs i m/yr, Areas in meters, so Mo is N*m/yr
-Mo_fault = mu*sum(A_top.*bs_top)+mu*sum(A_bot.*bs_bot) + mu*sum(A_bot.*bs_bot);
+Mo_fault = mu*sum(A_top.*bs_top)+mu*sum(A_bot.*bs_bot);
 
 %off fault (distributed moments)
 


### PR DESCRIPTION
Fixed the following issues:

1.	Piecewise smoothing input should use pm_top_seg_id instead of pm_top_seg_num to find unique patch IDs
2.	Depth offset implemented during Okada was cumulative instead of static (e.g. patches moved deeper during the loop)
3.	Top_perp greens functions were created using non-perp elastic components
4.     On-fault moment source calculations added lower patch contribution twice

